### PR TITLE
ValueToBoolConverter

### DIFF
--- a/Tests/ValueConverters.NetFx.Tests/ValueConverters.NetFx.Tests.csproj
+++ b/Tests/ValueConverters.NetFx.Tests/ValueConverters.NetFx.Tests.csproj
@@ -87,6 +87,7 @@
   <ItemGroup>
     <Compile Include="IsEmptyConverterTests.cs" />
     <Compile Include="Properties\xunit.assembly.config.cs" />
+    <Compile Include="ValueToBoolConverterTests.cs" />
     <Compile Include="VisibilityInverterTests.cs" />
     <Compile Include="EnumWrapperTests.cs" />
     <Compile Include="StringLengthToBoolConverterTests.cs" />

--- a/Tests/ValueConverters.NetFx.Tests/ValueToBoolConverterTests.cs
+++ b/Tests/ValueConverters.NetFx.Tests/ValueToBoolConverterTests.cs
@@ -1,5 +1,7 @@
 ﻿using System.Windows.Data;
 
+using FluentAssertions;
+
 using Xunit;
 
 namespace ValueConverters.NetFx.Tests
@@ -9,35 +11,35 @@ namespace ValueConverters.NetFx.Tests
         [Fact]
         public void ShouldConvertTrue()
         {
-            const int trueValue = 42;
-            IValueConverter converter = new ValueToBoolConverter<int> {TrueValue = trueValue};
+            const int TrueValue = 42;
+            IValueConverter converter = new ValueToBoolConverter<int> { TrueValue = TrueValue };
 
-            object result = converter.Convert(trueValue, null, null, null);
+            var result = converter.Convert(TrueValue, null, null, null);
 
-            Assert.True((bool)result);
+            result.Should().Be(true);
         }
 
         [Fact]
         public void ShouldConvertFalse()
         {
-            const int trueValue = 42;
-            IValueConverter converter = new ValueToBoolConverter<int> { TrueValue = trueValue };
-            const int input = trueValue + 1;
+            const int TrueValue = 42;
+            IValueConverter converter = new ValueToBoolConverter<int> { TrueValue = TrueValue };
+            const int Input = TrueValue + 1;
 
-            object result = converter.Convert(input, null, null, null);
+            var result = converter.Convert(Input, null, null, null);
 
-            Assert.False((bool)result);
+            result.Should().Be(false);
         }
 
         [Fact]
         public void ShouldConvertNull()
         {
-            const object trueValue = null;
-            IValueConverter converter = new ValueToBoolConverter<object> {TrueValue = trueValue};
+            const object TrueValue = null;
+            IValueConverter converter = new ValueToBoolConverter<object> { TrueValue = TrueValue };
 
-            object result = converter.Convert(trueValue, null, null, null);
+            var result = converter.Convert(TrueValue, null, null, null);
 
-            Assert.True((bool)result);
+            result.Should().Be(true);
         }
     }
 }

--- a/Tests/ValueConverters.NetFx.Tests/ValueToBoolConverterTests.cs
+++ b/Tests/ValueConverters.NetFx.Tests/ValueToBoolConverterTests.cs
@@ -1,0 +1,43 @@
+﻿using System.Windows.Data;
+
+using Xunit;
+
+namespace ValueConverters.NetFx.Tests
+{
+    public class ValueToBoolConverterTests
+    {
+        [Fact]
+        public void ShouldConvertTrue()
+        {
+            const int trueValue = 42;
+            IValueConverter converter = new ValueToBoolConverter<int> {TrueValue = trueValue};
+
+            object result = converter.Convert(trueValue, null, null, null);
+
+            Assert.True((bool)result);
+        }
+
+        [Fact]
+        public void ShouldConvertFalse()
+        {
+            const int trueValue = 42;
+            IValueConverter converter = new ValueToBoolConverter<int> { TrueValue = trueValue };
+            const int input = trueValue + 1;
+
+            object result = converter.Convert(input, null, null, null);
+
+            Assert.False((bool)result);
+        }
+
+        [Fact]
+        public void ShouldConvertNull()
+        {
+            const object trueValue = null;
+            IValueConverter converter = new ValueToBoolConverter<object> {TrueValue = trueValue};
+
+            object result = converter.Convert(trueValue, null, null, null);
+
+            Assert.True((bool)result);
+        }
+    }
+}

--- a/ValueConverters.Forms.NuGet/Package.nuspec
+++ b/ValueConverters.Forms.NuGet/Package.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>ValueConverters.Forms</id>
-    <version>1.0.6-pre1</version>
+    <version>1.0.6-pre2</version>
     <title>ValueConverters.NET for Xamarin.Forms</title>
     <authors>Thomas Galliker</authors>
     <licenseUrl>https://raw.githubusercontent.com/thomasgalliker/ValueConverters.NET/master/LICENSE.txt</licenseUrl>
@@ -18,6 +18,7 @@
     <releaseNotes>
 1.0.6
 - Added StringToDecimalConverter
+- Added ValueToBoolConverter
 
 1.0.4
 - Fix nuget package dependency problem

--- a/ValueConverters.NetFx/Properties/AssemblyInfo.cs
+++ b/ValueConverters.NetFx/Properties/AssemblyInfo.cs
@@ -23,4 +23,4 @@ using System.Runtime.InteropServices;
 [assembly: Guid("efc0655a-c5b8-4b71-b130-3ba06f43287d")]
 
 [assembly: AssemblyVersion("1.0.6")]
-[assembly: AssemblyFileVersion("1.0.6-pre1")]
+[assembly: AssemblyFileVersion("1.0.6-pre2")]

--- a/ValueConverters.NuGet/Package.nuspec
+++ b/ValueConverters.NuGet/Package.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>ValueConverters</id>
-    <version>1.0.6-pre1</version>
+    <version>1.0.6-pre2</version>
     <title>ValueConverters.NET</title>
     <authors>Thomas Galliker</authors>
     <licenseUrl>http://opensource.org/licenses/Apache-2.0</licenseUrl>
@@ -18,6 +18,7 @@
     <releaseNotes>
 1.0.6
 - Added StringToDecimalConverter
+- Added ValueToBoolConverter
 
 1.0.5
 - Added IsEmptyConverter to check for empty strings and other IEnumerables

--- a/ValueConverters.Shared/PropertyHelper.cs
+++ b/ValueConverters.Shared/PropertyHelper.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Globalization;
+
+#if XAMARIN
+using Xamarin.Forms;
+using Property = Xamarin.Forms.BindableProperty;
+#else
+using Property = System.Windows.DependencyProperty;
+#endif
+
+#if NETFX || WINDOWS_PHONE
+using System.Windows;
+#elif (NETFX_CORE)
+using Windows.UI.Xaml;
+#endif
+
+namespace ValueConverters
+{
+    class PropertyHelper
+    {
+        public static Property Create<T, TParent>(string name, T defaultValue) =>
+#if XAMARIN
+            Property.Create(name, typeof(T), typeof(TParent), defaultValue);
+#else
+            Property.Register(name, typeof(T), typeof(TParent), new PropertyMetadata(defaultValue));
+#endif
+
+        public static Property Create<T, TParent>(string name) => Create<T, TParent>(name, default(T));
+    }
+}

--- a/ValueConverters.Shared/PropertyHelper.cs
+++ b/ValueConverters.Shared/PropertyHelper.cs
@@ -1,22 +1,21 @@
-﻿using System;
-using System.Globalization;
-
-#if XAMARIN
-using Xamarin.Forms;
-using Property = Xamarin.Forms.BindableProperty;
-#else
-using Property = System.Windows.DependencyProperty;
-#endif
-
-#if NETFX || WINDOWS_PHONE
+﻿#if (NETFX || WINDOWS_PHONE)
 using System.Windows;
+using System.Windows.Data;
+using Property = System.Windows.DependencyProperty;
+
 #elif (NETFX_CORE)
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Data;
+using Property = Windows.UI.Xaml.DependencyProperty;
+
+#elif (XAMARIN)
+using Xamarin.Forms;
+using Property = Xamarin.Forms.BindableProperty;
 #endif
 
 namespace ValueConverters
 {
-    class PropertyHelper
+    static class PropertyHelper
     {
         public static Property Create<T, TParent>(string name, T defaultValue) =>
 #if XAMARIN

--- a/ValueConverters.Shared/ValueConverters.Shared.projitems
+++ b/ValueConverters.Shared/ValueConverters.Shared.projitems
@@ -21,6 +21,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)BoolToValueConverterBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)BoolToVisibilityConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ConverterBase.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)PropertyHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SingletonConverterBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DateTimeConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DateTimeConverterBase.cs" />
@@ -35,6 +36,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)IsEmptyConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ObservableObject.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)StringLengthToBoolConverter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ValueToBoolConverter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ValueToBoolConverterBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)VisibilityInverter.cs" />
   </ItemGroup>
 </Project>

--- a/ValueConverters.Shared/ValueToBoolConverter.cs
+++ b/ValueConverters.Shared/ValueToBoolConverter.cs
@@ -1,32 +1,38 @@
-﻿using System;
-using System.Globalization;
-
-#if XAMARIN
-using Xamarin.Forms;
-using Property = Xamarin.Forms.BindableProperty;
-#else
-using Property = System.Windows.DependencyProperty;
-#endif
-
-#if NETFX || WINDOWS_PHONE
+﻿#if (NETFX || WINDOWS_PHONE)
 using System.Windows;
+using System.Windows.Data;
+using Property = System.Windows.DependencyProperty;
+
 #elif (NETFX_CORE)
 using Windows.UI.Xaml;
-#endif
+using Windows.UI.Xaml.Data;
+using Property = Windows.UI.Xaml.DependencyProperty;
 
+#elif (XAMARIN)
+using Xamarin.Forms;
+using Property = Xamarin.Forms.BindableProperty;
+#endif
 
 namespace ValueConverters
 {
     public class ValueToBoolConverter<T> : ValueToBoolConverterBase<T, ValueToBoolConverter<T>>
     {
         public override T TrueValue {
-            get => (T)this.GetValue(TrueValueProperty);
-            set => this.SetValue(TrueValueProperty, value);
+            get
+            {
+                return (T)this.GetValue(TrueValueProperty);
+            }
+            set
+            {
+                this.SetValue(TrueValueProperty, value);
+            }
         }
 
         public static readonly Property TrueValueProperty =
             PropertyHelper.Create<T, ValueToBoolConverter<T>>(nameof(TrueValue));
     }
 
-    public class ValueToBoolConverter: ValueToBoolConverter<object> { }
+    public class ValueToBoolConverter : ValueToBoolConverter<object>
+    {
+    }
 }

--- a/ValueConverters.Shared/ValueToBoolConverter.cs
+++ b/ValueConverters.Shared/ValueToBoolConverter.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Globalization;
+
+#if XAMARIN
+using Xamarin.Forms;
+using Property = Xamarin.Forms.BindableProperty;
+#else
+using Property = System.Windows.DependencyProperty;
+#endif
+
+#if NETFX || WINDOWS_PHONE
+using System.Windows;
+#elif (NETFX_CORE)
+using Windows.UI.Xaml;
+#endif
+
+
+namespace ValueConverters
+{
+    public class ValueToBoolConverter<T> : ValueToBoolConverterBase<T, ValueToBoolConverter<T>>
+    {
+        public override T TrueValue {
+            get => (T)this.GetValue(TrueValueProperty);
+            set => this.SetValue(TrueValueProperty, value);
+        }
+
+        public static readonly Property TrueValueProperty =
+            PropertyHelper.Create<T, ValueToBoolConverter<T>>(nameof(TrueValue));
+    }
+
+    public class ValueToBoolConverter: ValueToBoolConverter<object> { }
+}

--- a/ValueConverters.Shared/ValueToBoolConverterBase.cs
+++ b/ValueConverters.Shared/ValueToBoolConverterBase.cs
@@ -1,38 +1,46 @@
 ﻿using System;
 using System.Globalization;
 
-#if XAMARIN
-using Xamarin.Forms;
-using Property = Xamarin.Forms.BindableProperty;
-#else
-using Property = System.Windows.DependencyProperty;
-#endif
-
-#if NETFX || WINDOWS_PHONE
+#if (NETFX || WINDOWS_PHONE)
 using System.Windows;
+using System.Windows.Data;
+using Property = System.Windows.DependencyProperty;
+
 #elif (NETFX_CORE)
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Data;
+using Property = Windows.UI.Xaml.DependencyProperty;
+
+#elif (XAMARIN)
+using Xamarin.Forms;
+using Property = Xamarin.Forms.BindableProperty;
 #endif
 
 namespace ValueConverters
 {
     public abstract class ValueToBoolConverterBase<T, TConverter> : ConverterBase
-        where TConverter: new()
+        where TConverter : new()
     {
         public abstract T TrueValue { get; set; }
 
-        public bool IsInverted {
-            get => (bool)this.GetValue(IsInvertedProperty);
-            set => this.SetValue(IsInvertedProperty, value);
+        public bool IsInverted
+        {
+            get
+            {
+                return (bool)this.GetValue(IsInvertedProperty);
+            }
+            set
+            {
+                this.SetValue(IsInvertedProperty, value);
+            }
         }
 
         protected override object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             T trueValue = this.TrueValue;
-            return object.Equals(value, trueValue) ^ this.IsInverted;
+            return Equals(value, trueValue) ^ this.IsInverted;
         }
 
-        public static readonly Property IsInvertedProperty =
-            PropertyHelper.Create<bool, ValueToBoolConverterBase<T,TConverter>>(nameof(IsInverted));
+        public static readonly Property IsInvertedProperty = PropertyHelper.Create<bool, ValueToBoolConverterBase<T, TConverter>>(nameof(IsInverted));
     }
 }

--- a/ValueConverters.Shared/ValueToBoolConverterBase.cs
+++ b/ValueConverters.Shared/ValueToBoolConverterBase.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Globalization;
+
+#if XAMARIN
+using Xamarin.Forms;
+using Property = Xamarin.Forms.BindableProperty;
+#else
+using Property = System.Windows.DependencyProperty;
+#endif
+
+#if NETFX || WINDOWS_PHONE
+using System.Windows;
+#elif (NETFX_CORE)
+using Windows.UI.Xaml;
+#endif
+
+namespace ValueConverters
+{
+    public abstract class ValueToBoolConverterBase<T, TConverter> : ConverterBase
+        where TConverter: new()
+    {
+        public abstract T TrueValue { get; set; }
+
+        public bool IsInverted {
+            get => (bool)this.GetValue(IsInvertedProperty);
+            set => this.SetValue(IsInvertedProperty, value);
+        }
+
+        protected override object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            T trueValue = this.TrueValue;
+            return object.Equals(value, trueValue) ^ this.IsInverted;
+        }
+
+        public static readonly Property IsInvertedProperty =
+            PropertyHelper.Create<bool, ValueToBoolConverterBase<T,TConverter>>(nameof(IsInverted));
+    }
+}

--- a/ValueConverters.UWP/Properties/AssemblyInfo.cs
+++ b/ValueConverters.UWP/Properties/AssemblyInfo.cs
@@ -25,5 +25,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.6")]
 [assembly: AssemblyVersion("1.0.6")]
-[assembly: AssemblyFileVersion("1.0.6-pre1")]
+[assembly: AssemblyFileVersion("1.0.6-pre2")]
 [assembly: ComVisible(false)]

--- a/ValueConverters.WindowsPhone8/Properties/AssemblyInfo.cs
+++ b/ValueConverters.WindowsPhone8/Properties/AssemblyInfo.cs
@@ -33,5 +33,5 @@ using System.Resources;
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
 [assembly: AssemblyVersion("1.0.6")]
-[assembly: AssemblyFileVersion("1.0.6-pre1")]
+[assembly: AssemblyFileVersion("1.0.6-pre2")]
 [assembly: NeutralResourcesLanguageAttribute("en-US")]

--- a/ValueConverters.WindowsPhone81/Properties/AssemblyInfo.cs
+++ b/ValueConverters.WindowsPhone81/Properties/AssemblyInfo.cs
@@ -25,5 +25,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.6")]
 [assembly: AssemblyVersion("1.0.6")]
-[assembly: AssemblyFileVersion("1.0.6-pre1")]
+[assembly: AssemblyFileVersion("1.0.6-pre2")]
 [assembly: ComVisible(false)]

--- a/ValueConverters.WindowsStore/Properties/AssemblyInfo.cs
+++ b/ValueConverters.WindowsStore/Properties/AssemblyInfo.cs
@@ -25,5 +25,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.6")]
 [assembly: AssemblyVersion("1.0.6")]
-[assembly: AssemblyFileVersion("1.0.6-pre1")]
+[assembly: AssemblyFileVersion("1.0.6-pre2")]
 [assembly: ComVisible(false)]

--- a/ValueConverters/Properties/AssemblyInfo.cs
+++ b/ValueConverters/Properties/AssemblyInfo.cs
@@ -27,4 +27,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.6")]
 [assembly: AssemblyVersion("1.0.6")]
-[assembly: AssemblyFileVersion("1.0.6-pre1")]
+[assembly: AssemblyFileVersion("1.0.6-pre2")]


### PR DESCRIPTION
Converts value to ```true``` if it equals to a value, specified by ```TrueValue```, otherwise returns ```false```. Does not convert back.
Useful, for example, to set ```IsEnabled``` for a "Remove Current" button if no item is selected in a list (```SelectedItem == null```).
```TrueValue``` gives additional flexibility.