### PR TITLE
enabled ConvertBack on ValueToBoolConverter

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+[*.cs]
+indent_style = space
+indent_size = 4
+csharp_new_line_before_open_brace = true
+csharp_style_expression_bodied_properties = false

--- a/Tests/ValueConverters.NetFx.Tests/ValueToBoolConverterTests.cs
+++ b/Tests/ValueConverters.NetFx.Tests/ValueToBoolConverterTests.cs
@@ -41,5 +41,53 @@ namespace ValueConverters.NetFx.Tests
 
             result.Should().Be(true);
         }
+
+        [Fact]
+        public void ShouldConvertTrueBack()
+        {
+            const int TrueValue = 42;
+            IValueConverter converter = new ValueToBoolConverter<int?>{TrueValue = TrueValue};
+
+            var result = converter.ConvertBack(true, typeof(int?), null, null);
+
+            result.Should().Be(TrueValue);
+        }
+
+        [Fact]
+        public void ShouldConvertFalseBack()
+        {
+            const int FalseValue = 42;
+            IValueConverter converter = new ValueToBoolConverter<int?>{FalseValue = FalseValue};
+
+            var result = converter.ConvertBack(false, typeof(int?), null, null);
+
+            result.Should().Be(FalseValue);
+        }
+
+        [Fact]
+        public void ShouldConvertFalseBackToNull()
+        {
+            IValueConverter converter = new ValueToBoolConverter<int?>();
+
+            var result = converter.ConvertBack(false, typeof(int?), null, null);
+
+            result.Should().Be(null);
+        }
+
+        [Fact]
+        public void ShouldUseIsInvertedWhenConvertingBack()
+        {
+            const int FalseValue = -42;
+            const int TrueValue = 42;
+            IValueConverter converter = new ValueToBoolConverter<int?> {
+                FalseValue = FalseValue,
+                TrueValue = TrueValue,
+                IsInverted = true,
+            };
+
+            var result = converter.ConvertBack(false, typeof(int?), null, null);
+
+            result.Should().Be(TrueValue);
+        }
     }
 }

--- a/Tests/ValueConverters.NetFx.Tests/ValueToBoolConverterTests.cs
+++ b/Tests/ValueConverters.NetFx.Tests/ValueToBoolConverterTests.cs
@@ -89,5 +89,23 @@ namespace ValueConverters.NetFx.Tests
 
             result.Should().Be(TrueValue);
         }
+
+        [Fact]
+        public void ShouldUseBaseWhenConverting()
+        {
+            const int TrueValue = 42;
+            const int FalseValue = 0;
+            IValueConverter converter = new ValueToBoolConverter<int> {
+                TrueValue = TrueValue,
+                FalseValue = FalseValue,
+                BaseOnFalseValue = true,
+            };
+            const int Input = TrueValue + 1;
+
+            var result = converter.Convert(Input, null, null, null);
+
+            result.Should().Be(true);
+
+        }
     }
 }

--- a/ValueConverters.Shared/ReversibleValueToBoolConverterBase.cs
+++ b/ValueConverters.Shared/ReversibleValueToBoolConverterBase.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Globalization;
+
+namespace ValueConverters
+{
+    public abstract class ReversibleValueToBoolConverterBase<T, TConverter> 
+        : ValueToBoolConverterBase<T, TConverter>
+        where TConverter : new()
+    {
+        public abstract T FalseValue { get; set; }
+
+        protected override object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return true.Equals(value) ^ this.IsInverted ? this.TrueValue : this.FalseValue;
+        }
+    }
+}

--- a/ValueConverters.Shared/ReversibleValueToBoolConverterBase.cs
+++ b/ValueConverters.Shared/ReversibleValueToBoolConverterBase.cs
@@ -1,6 +1,21 @@
 ﻿using System;
 using System.Globalization;
 
+#if (NETFX || WINDOWS_PHONE)
+using System.Windows;
+using System.Windows.Data;
+using Property = System.Windows.DependencyProperty;
+
+#elif (NETFX_CORE)
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Data;
+using Property = Windows.UI.Xaml.DependencyProperty;
+
+#elif (XAMARIN)
+using Xamarin.Forms;
+using Property = Xamarin.Forms.BindableProperty;
+#endif
+
 namespace ValueConverters
 {
     public abstract class ReversibleValueToBoolConverterBase<T, TConverter> 
@@ -9,9 +24,36 @@ namespace ValueConverters
     {
         public abstract T FalseValue { get; set; }
 
+        public bool BaseOnFalseValue
+        {
+            get
+            {
+                return (bool)this.GetValue(BaseOnFalseValueProperty);
+            }
+            set
+            {
+                this.SetValue(BaseOnFalseValueProperty, value);
+            }
+        }
+
+        protected override object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (!this.BaseOnFalseValue)
+            {
+                return base.Convert(value, targetType, parameter, culture);
+            }
+            else
+            {
+                T falseValue = this.FalseValue;
+                return !Equals(value, falseValue) ^ this.IsInverted;
+            }
+        }
+
         protected override object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
             return true.Equals(value) ^ this.IsInverted ? this.TrueValue : this.FalseValue;
         }
+
+        public static readonly Property BaseOnFalseValueProperty = PropertyHelper.Create<bool, ValueToBoolConverterBase<T, TConverter>>(nameof(BaseOnFalseValueProperty));
     }
 }

--- a/ValueConverters.Shared/ValueConverters.Shared.projitems
+++ b/ValueConverters.Shared/ValueConverters.Shared.projitems
@@ -23,6 +23,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)BoolToVisibilityConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ConverterBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DoubleToBoolConverter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ReversibleValueToBoolConverterBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)StringToBoolConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IntegerToBoolConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)NullToBoolConverter.cs" />

--- a/ValueConverters.Shared/ValueToBoolConverter.cs
+++ b/ValueConverters.Shared/ValueToBoolConverter.cs
@@ -15,7 +15,7 @@ using Property = Xamarin.Forms.BindableProperty;
 
 namespace ValueConverters
 {
-    public class ValueToBoolConverter<T> : ValueToBoolConverterBase<T, ValueToBoolConverter<T>>
+    public class ValueToBoolConverter<T> : ReversibleValueToBoolConverterBase<T, ValueToBoolConverter<T>>
     {
         public override T TrueValue {
             get
@@ -30,6 +30,20 @@ namespace ValueConverters
 
         public static readonly Property TrueValueProperty =
             PropertyHelper.Create<T, ValueToBoolConverter<T>>(nameof(TrueValue));
+
+        public override T FalseValue {
+            get
+            {
+                return (T)this.GetValue(FalseValueProperty);
+            }
+            set
+            {
+                this.SetValue(FalseValueProperty, value);
+            }
+        }
+
+        public static readonly Property FalseValueProperty =
+            PropertyHelper.Create<T, ValueToBoolConverter<T>>(nameof(FalseValue));
     }
 
     public class ValueToBoolConverter : ValueToBoolConverter<object>

--- a/ValueConverters.sln
+++ b/ValueConverters.sln
@@ -33,6 +33,14 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ValueConverters.Testdata", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ValueConverterSample.Contracts", "Samples\ValueConverterSample.Contracts\ValueConverterSample.Contracts.csproj", "{00E10374-C85B-49E4-9D6B-B1E866D3D0B5}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Repo", "Repo", "{6F8E6421-DA91-44F9-BB51-C1699927C09C}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+		.gitignore = .gitignore
+		LICENSE.txt = LICENSE.txt
+		README.md = README.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		ValueConverters.Shared\ValueConverters.Shared.projitems*{15371be7-c46d-40ae-bef1-8f44497e696d}*SharedItemsImports = 4


### PR DESCRIPTION
This change enables converting back with ValueToBoolConverter.

New intermediate base abstract class `ReversibleValueToBoolConverterBase<T, TConverter>` is added, that exposes `FalseValue` property (can't add a new abstract property into existing converter class, as it would break the contract).